### PR TITLE
fix: Fix static code chcek

### DIFF
--- a/internal/controller/kuik/cachedimage_controller.go
+++ b/internal/controller/kuik/cachedimage_controller.go
@@ -352,21 +352,13 @@ func (r *CachedImageReconciler) cacheImage(cachedImage *kuikv1alpha1.CachedImage
 	totalSizeAvailable := false
 	onUpdated := func(update v1.Update) {
 
-		needUpdate := false
-		if lastWriteComplete != update.Complete && update.Complete == update.Total {
-			// Update is needed whenever the writing complmetes.
-			needUpdate = true
-		}
-
-		if time.Since(lastUpdateTime).Seconds() >= 5 {
-			// Update is needed if last update is more than 5 seconds ago
-			needUpdate = true
-		}
+		isCompleted := lastWriteComplete != update.Complete && update.Complete == update.Total
+		needUpdate := time.Since(lastUpdateTime).Seconds() >= 5 || isCompleted
 
 		statusLock.Lock()
 		defer statusLock.Unlock()
 		if needUpdate && !totalSizeAvailable {
-			updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
+			_ = updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
 				cachedImage.Status.Progress.Total = update.Total
 				cachedImage.Status.Progress.Available = update.Complete
 			})
@@ -381,7 +373,7 @@ func (r *CachedImageReconciler) cacheImage(cachedImage *kuikv1alpha1.CachedImage
 		totalSizeAvailable = true // Disable future progress update.
 		statusLock.Unlock()
 
-		updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
+		_ = updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
 			cachedImage.Status.Progress.Total = totalSize
 			cachedImage.Status.Progress.Available = totalSize
 		})

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -271,24 +271,23 @@ func getImageSizeByManifestIndex(tt v1.ImageIndex) (int64, error) {
 	}
 
 	for _, child := range children {
-		child := child
-		switch child.(type) {
+		switch typedChild := child.(type) {
 		case v1.ImageIndex:
-			size, err := getImageSizeByManifestIndex(child.(v1.ImageIndex))
+			size, err := getImageSizeByManifestIndex(typedChild)
 			if err != nil {
 				return 0, err
 			}
 			totalSize += size
 
 		case v1.Image:
-			imageSize, err := getImageSizeByImageManifest(child.(v1.Image))
+			imageSize, err := getImageSizeByImageManifest(typedChild)
 			if err != nil {
 				return 0, err
 			}
 			totalSize += imageSize
 
 		case v1.Layer:
-			layerSize, err := child.(v1.Layer).Size()
+			layerSize, err := typedChild.Size()
 			if err != nil {
 				return 0, err
 			}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -148,6 +148,7 @@ func CacheImage(imageName string, desc *remote.Descriptor, architectures []strin
 	case types.OCIImageIndex, types.DockerManifestList:
 		index, err := desc.ImageIndex()
 		if err != nil {
+			close(progressUpdate)
 			return err
 		}
 
@@ -177,6 +178,7 @@ func CacheImage(imageName string, desc *remote.Descriptor, architectures []strin
 	default:
 		image, err := desc.Image()
 		if err != nil {
+			close(progressUpdate)
 			return err
 		}
 


### PR DESCRIPTION
```
  Error: internal/controller/kuik/cachedimage_controller.go:377:16: Error return value is not checked (errcheck)
  			updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
  			            ^
  Error: internal/controller/kuik/cachedimage_controller.go:392:15: Error return value is not checked (errcheck)
  		updateStatus(r.Client, cachedImage, desc, func(status *kuikv1alpha1.CachedImageStatus) {
  		            ^
  Error: internal/controller/kuik/cachedimage_controller.go:363:3: QF1007: could merge conditional assignment into variable declaration (staticcheck)
  		needUpdate := false
  		^
  Error: internal/registry/registry.go:346:10: S1034: assigning the result of this type assertion to a variable (switch child := child.(type)) could eliminate type assertions in switch cases (staticcheck)
  		switch child.(type) {
  		       ^
  Error: internal/registry/registry.go:348:45: S1034(related information): could eliminate this type assertion (staticcheck)
  			size, err := getImageSizeByManifestIndex(child.(v1.ImageIndex))
  			                                         ^
  Error: internal/registry/registry.go:355:50: S1034(related information): could eliminate this type assertion (staticcheck)
  			imageSize, err := getImageSizeByImageManifest(child.(v1.Image))
  			                                              ^
  Error: internal/registry/registry.go:362:22: S1034(related information): could eliminate this type assertion (staticcheck)
  			layerSize, err := child.(v1.Layer).Size()
  			                  ^
```